### PR TITLE
control-computer

### DIFF
--- a/screenpipe-js/mcp-server/src/browser-sdk-wrapper.ts
+++ b/screenpipe-js/mcp-server/src/browser-sdk-wrapper.ts
@@ -1,0 +1,10 @@
+// Create a Node-compatible version of the browser SDK
+import { Operator } from "../../browser-sdk/src/Operator.js";
+
+// Skip PostHog initialization by creating a direct Operator instance
+const operator = new Operator("http://localhost:3030");
+
+// Export a compatible API
+export const pipe = {
+  operator
+};


### PR DESCRIPTION
sdk wrapper because of posthog not working in node